### PR TITLE
WIP: Ported renderLabel function to plugin

### DIFF
--- a/src/ol/style/label.js
+++ b/src/ol/style/label.js
@@ -1,0 +1,20 @@
+ol.style.Label = function(opt_options) {
+
+  this.computeScale(opt_options);
+
+  if (!opt_options.fill) {
+    opt_options.fill = new ol.style.Fill({
+      color: '#FF0000'
+    })
+  }
+
+  ol.style.Text.call(this, opt_options);
+
+};
+ol.inherits(ol.style.Text, ol.style.Fill);
+
+
+ol.style.Label.prototype.computeScale = function(opt_options) {
+  opt_options.scale = 0.2 * (
+    Math.log(opt_options.t) - Math.log(opt_options.min_t) + 0.5);
+};


### PR DESCRIPTION
@jsvde Ich hab mal die renderLabel Funktion in das Plugin übernommen. Dazu habe ich einen neuen Style erstellt (`osm.style.Label`). Ist das so, wie gedacht oder hätte ich das an einer anderen Stelle einfügen sollen?

Außerdem ist mir noch nicht klar, an welcher Stelle mein neuer Style verwendet werden soll.