### PR TITLE
Rendering performance

### DIFF
--- a/dist/ol-labels.js
+++ b/dist/ol-labels.js
@@ -106,9 +106,7 @@ function getMaxLabelLength(labelText) {
 };
 
 function resToMinT(res){
-
-
-
+  
   var zoom = Math.log2(156543.03390625) - Math.log2(res);
 
   console.log(res,zoom);
@@ -124,17 +122,13 @@ ol.source.Label = function(org_options) {
 
   this.labelServerUrl = org_options.url;
 
-  var options = {
-    format:new ol.format.GeoJSON(),
-    strategy:ol.loadingstrategy.bbox,
-    url: this.featureLoader.bind(this)
-  }
-
-
+  // TODO: Allow user to set own options here?!
   // overwrite needed options:
   org_options.format = new ol.format.GeoJSON();
   org_options.strategy = ol.loadingstrategy.bbox
   org_options.url = this.featureLoader.bind(this);
+  org_options.updateWhileAnimating = true;
+  org_options.updateWhileInteracting = true;
 
 
   // TODO: Search if there is a better solution than creating here a ol.View object

--- a/index-dev.html
+++ b/index-dev.html
@@ -24,10 +24,8 @@
           }),
           new ol.layer.Label({
             source: new ol.source.Label({
-              url: 'http://seeigel.informatik.uni-stuttgart.de:8181/label/citynames',
+              url: 'http://seeigel.informatik.uni-stuttgart.de:8080/label/citynames',
               labelClasses: ['city',],
-              updateWhileAnimating: true,
-              updateWhileInteracting: true,
             }),
             style: null
           })

--- a/index-dev.html
+++ b/index-dev.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="dist/ol-labels.css" type="text/css">
     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-    <script src="https://openlayers.org/en/v4.1.1/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v4.1.1/build/ol-debug.js"></script>
     <script src="dist/ol-labels.js"></script>
   </head>
   <body>
@@ -25,7 +25,9 @@
           new ol.layer.Label({
             source: new ol.source.Label({
               url: 'http://seeigel.informatik.uni-stuttgart.de:8080/label/citynames',
-              labelClasses: ['city',]
+              labelClasses: ['city',],
+              updateWhileAnimating: true,
+              updateWhileInteracting: true,
             }),
             style: null
           })
@@ -39,13 +41,13 @@
 
       // TODO: Implement another solution to reload label data on zoom or extent changes
       // On change event handler on view. Will be fired if center or resolution has been chnaged
-      map.getView().on('propertychange', function(e) {
-        // keys: center, resolution
-        // console.log("propertychange: ", e.key, e);
-        var vector_layer = map.getLayers().getArray()[1];
-        vector_layer.getSource().clear();
-        vector_layer.getSource().refresh();
-      });
+      // map.getView().on('propertychange', function(e) {
+      //   // keys: center, resolution
+      //   // console.log("propertychange: ", e.key, e);
+      //   var vector_layer = map.getLayers().getArray()[1];
+      //   vector_layer.getSource().clear();
+      //   vector_layer.getSource().refresh();
+      // });
 
     </script>
   </body>

--- a/index-dev.html
+++ b/index-dev.html
@@ -24,7 +24,7 @@
           }),
           new ol.layer.Label({
             source: new ol.source.Label({
-              url: 'http://seeigel.informatik.uni-stuttgart.de:8080/label/citynames',
+              url: 'http://seeigel.informatik.uni-stuttgart.de:8181/label/citynames',
               labelClasses: ['city',],
               updateWhileAnimating: true,
               updateWhileInteracting: true,

--- a/src/ol/layer/label.js
+++ b/src/ol/layer/label.js
@@ -3,21 +3,9 @@ ol.layer.Label = function(opt_options) {
   var options = opt_options || {};
 
   if(!options.style) {
-    // Set ol.style.Label as default style for ol.layer.Label
-    options.style = this.styleFunction.bind(this);
+    options.style = ol.style.Label
   }
 
   ol.layer.Vector.call(this, options);
 };
 ol.inherits(ol.layer.Label, ol.layer.Vector);
-
-/**
-* StyleFunction to generate the style for a label.
-* Doc: http://openlayers.org/en/latest/apidoc/ol.html#.StyleFunction
-* @param {ol.Feature} feature - ol.Feature object with attributes from geojson data that represents an text label.
-* @param {number} resolution - current resolution
-*/
-ol.layer.Label.prototype.styleFunction = function(feature, resolution) {
-  // Create new ol.style.Label object
-  return new ol.style.Label(feature);
-};

--- a/src/ol/source/label.js
+++ b/src/ol/source/label.js
@@ -2,17 +2,13 @@ ol.source.Label = function(org_options) {
 
   this.labelServerUrl = org_options.url;
 
-  var options = {
-    format:new ol.format.GeoJSON(),
-    strategy:ol.loadingstrategy.bbox,
-    url: this.featureLoader.bind(this)
-  }
-
-
+  // TODO: Allow user to set own options here?!
   // overwrite needed options:
   org_options.format = new ol.format.GeoJSON();
   org_options.strategy = ol.loadingstrategy.bbox
   org_options.url = this.featureLoader.bind(this);
+  org_options.updateWhileAnimating = true;
+  org_options.updateWhileInteracting = true;
 
 
   // TODO: Search if there is a better solution than creating here a ol.View object

--- a/src/ol/source/label.js
+++ b/src/ol/source/label.js
@@ -8,10 +8,17 @@ ol.source.Label = function(org_options) {
     url: this.featureLoader.bind(this)
   }
 
+
+  // overwrite needed options:
+  org_options.format = new ol.format.GeoJSON();
+  org_options.strategy = ol.loadingstrategy.bbox
+  org_options.url = this.featureLoader.bind(this);
+
+
   // TODO: Search if there is a better solution than creating here a ol.View object
   this.viewToCalcZoomLevel = new ol.View();
 
-  ol.source.Vector.call(this, options);
+  ol.source.Vector.call(this, org_options);
 };
 
 ol.source.Label.prototype = Object.create(ol.source.Vector.prototype);
@@ -42,9 +49,12 @@ ol.source.Label.prototype.addFeatureInternal = function(feature) {
 
 ol.source.Label.prototype.loadFeatures = function(extent, resolution, projection) {
   // this.loader_.call(this, extent, resolution, projection);
-  console.log('test');
   var zoomLevelFromResolution = this.viewToCalcZoomLevel.getZoomForResolution(resolution);
-  min_t = window.min_t = this.zoomLevelToMinT(zoomLevelFromResolution);
+
+  // var min_t = this.zoomLevelToMinT(zoomLevelFromResolution);
+  //
+  // console.log(zoomLevelFromResolution, min_t);
+
   var loadedExtentsRtree = this.loadedExtentsRtree_;
   var extentsToLoad = this.strategy_(extent, resolution);
   var i, ii;
@@ -86,7 +96,7 @@ ol.source.Label.prototype.featureLoader = function(extent, number, projection){
 
   // Set global variable min_t
   // TODO: Find better solution than global variable
-  min_t = window.min_t = this.zoomLevelToMinT(zoomLevelFromResolution);
+  var min_t = window.min_t = this.zoomLevelToMinT(zoomLevelFromResolution);
 
   var parameters = {
       x_min: min[0],
@@ -105,7 +115,7 @@ ol.source.Label.prototype.featureLoader = function(extent, number, projection){
  */
 ol.source.Label.prototype.zoomLevelToMinT = function(zoom) {
   if (zoom <= 3) {
-    return Number.POSITIVE_INFINITY;
+    return 0.01;
   } else {
     return Math.pow(2, 9 - (zoom - 1));
   }

--- a/src/ol/style/label.js
+++ b/src/ol/style/label.js
@@ -94,9 +94,7 @@ function getMaxLabelLength(labelText) {
 };
 
 function resToMinT(res){
-
-
-
+  
   var zoom = Math.log2(156543.03390625) - Math.log2(res);
 
   console.log(res,zoom);

--- a/src/ol/style/label.js
+++ b/src/ol/style/label.js
@@ -20,6 +20,14 @@ ol.style.Label = function(feature) {
     return null;
   }
 
+  console.log(t,window.min_t);
+  console.log('');
+  if(t < window.min_t){
+    // return null;
+    return;
+    // this.fill = new ol.style.Fill({color: [0,0,0,0]})
+  }
+
   // Calculate the label size by the given value label factor
   var calculatedlabelFactor = 1.1 * parseInt(labelFactor);
   var fontConfig = labelFactor + "px " + labelFontType;

--- a/src/ol/style/label.js
+++ b/src/ol/style/label.js
@@ -3,29 +3,28 @@
  * Constructor of ol.style.Label
  * @param {ol.Feature} feature - ol.Feature object with attributes from geojson data that represents an text label.
  */
-ol.style.Label = function(feature) {
+ol.style.Label = function(feature,resolution) {
 
   // Get needed fields from feature object
   var labelText = feature.get("name");
   var t = feature.get("t");
   var labelFactor = feature.get("lbl_fac");
 
-  var labelTextColor = '#0000FF';
+  var labelTextColor = '#333';
   var labelFontType = "Consolas";
   var labelCircleColor = "red";
 
 
   // Don't show too big labels like a capital cityname on a high zoom levels
-  if(window.min_t < 0.125 && t > 12){
-    return null;
-  }
+  //if(window.min_t > t){
 
-  console.log(t,window.min_t);
-  console.log('');
-  if(t < window.min_t){
+  //}
+  var min_t = resToMinT(resolution);
+
+  if(min_t > t){
     // return null;
-    return;
-    // this.fill = new ol.style.Fill({color: [0,0,0,0]})
+    // console.log(labelText,window.min_t,t);
+    return null;
   }
 
   // Calculate the label size by the given value label factor
@@ -37,7 +36,7 @@ ol.style.Label = function(feature) {
     labelText = labelText.replace("\\n", "\n");
   }
 
-  var maxLabelLength = this.getMaxLabelLength(labelText);
+  var maxLabelLength = getMaxLabelLength(labelText);
   var circleRadius = labelFactor * maxLabelLength * 0.26;
 
   this.image = new ol.style.Circle({
@@ -55,17 +54,33 @@ ol.style.Label = function(feature) {
     })
   });
 
+  if(window.min_t < 0.125 && t > 12){
+    this.text = new ol.style.Text({
+      text: labelText,
+      font: fontConfig,
+      fill: new ol.style.Fill({
+        color: [0, 0, 0, .3]
+      })
+    });
+  }
+
+  var style = new ol.style.Style({
+        image: window.debug == true ? this.image : null,
+        text: this.text
+      });
+
+  return style;
+
   // Pass this Label object as options params for ol.style.Style
-  ol.style.Style.call(this, this);
+  // ol.style.Style.call(this, this);
 };
-ol.inherits(ol.style.Label, ol.style.Style);
 
 
 /**
  * Get max label length for the case that label has more than one row, e.g. Frankfurt\nam Main
  * @param {string} labelText - text of the label
  */
-ol.style.Label.prototype.getMaxLabelLength = function(labelText) {
+function getMaxLabelLength(labelText) {
 
   var lines = labelText.split("\n");
   var maxLength = 0;
@@ -77,3 +92,18 @@ ol.style.Label.prototype.getMaxLabelLength = function(labelText) {
   }
   return maxLength;
 };
+
+function resToMinT(res){
+
+
+
+  var zoom = Math.log2(156543.03390625) - Math.log2(res);
+
+  console.log(res,zoom);
+
+  if (zoom <= 3) {
+    return 0.01;
+  } else {
+    return Math.pow(2, 9 - (zoom - 1));
+  }
+}


### PR DESCRIPTION
- Use ol-debug temporary to overwrite original inherited prototypes (loadFeatures)
- Incorporate zoom level/resolution in caching mechanism
- Render labels without circles, use window.debug = true in the browser to draw circles for testing
- Lower opacity for labels with high t-value when viewed on a very high zoom level
- Use static function as styleFunction as recommended by open layer docs
- temporary hacky resolution to zoom-function converter to obtain correct min_t while updating, prevent globale min_t variable